### PR TITLE
Mmap cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,46 @@ rbTree is a simple red-black tree for storing data in a sorted manner
 ## go --version
 ## > go version go1.9.3 linux/amd64
 
-# rbTree
-BenchmarkGet-16                     500    3672168 ns/op         0 B/op        0 allocs/op
-BenchmarkSortedGetPut-16            200    7257202 ns/op      7208 B/op        0 allocs/op # Fastest
-BenchmarkSortedPut-16               300    3897592 ns/op      4805 B/op        0 allocs/op # Fastest
-BenchmarkReversePut-16              300    3831036 ns/op      4805 B/op        0 allocs/op # Fastest
-BenchmarkRandomPut-16               300    4314028 ns/op      4805 B/op        0 allocs/op # Fastest
-BenchmarkForEach-16               20000      94837 ns/op         0 B/op        0 allocs/op
+# RBTree (byteslice)
+BenchmarkRBTGet-16                     500     3437782 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTSortedGetPut-16            200     7051656 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTSortedPut-16               500     3719148 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTReversePut-16              300     3790151 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTRandomPut-16               300     4142005 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTForEach-16               20000       93689 ns/op         0 B/op        0 allocs/op
+
+# RBTree (MMap)
+BenchmarkRBTMMapGet-16                 500     3481923 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTMMapSortedGetPut-16        200     6874071 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTMMapSortedPut-16           500     3695351 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTMMapReversePut-16          500     3699271 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTMMapRandomPut-16           300     4375106 ns/op         0 B/op        0 allocs/op
+BenchmarkRBTMMapForEach-16           20000       95564 ns/op         0 B/op        0 allocs/op
 
 # Skiplist (github.com/OneOfOne/skiplist)
-BenchmarkSkiplistGet-16             500    2610549 ns/op         0 B/op        0 allocs/op # Fastest
-BenchmarkSkiplistSortedGetPut-16    200    8072147 ns/op    323778 B/op    10100 allocs/op
-BenchmarkSkiplistSortedPut-16       300    5324434 ns/op    322520 B/op    10066 allocs/op
-BenchmarkSkiplistReversePut-16      300    6091060 ns/op    322521 B/op    10066 allocs/op
-BenchmarkSkiplistRandomPut-16       200    6747146 ns/op    323783 B/op    10100 allocs/op
-BenchmarkSkiplistForEach-16       30000      51041 ns/op         0 B/op        0 allocs/op # Fastest
+BenchmarkSkiplistGet-16                500     2505922 ns/op         0 B/op        0 allocs/op
+BenchmarkSkiplistSortedGetPut-16       200     8779344 ns/op    323786 B/op    10100 allocs/op
+BenchmarkSkiplistSortedPut-16          300     4912010 ns/op    322520 B/op    10066 allocs/op
+BenchmarkSkiplistReversePut-16         300     5556532 ns/op    322521 B/op    10066 allocs/op
+BenchmarkSkiplistRandomPut-16          200     7497191 ns/op    323779 B/op    10100 allocs/op
+BenchmarkSkiplistForEach-16          30000       51236 ns/op         0 B/op        0 allocs/op
+
+# B+Tree (github.com/cznic/b)
+BenchmarkCznicGet-16                   300     5902947 ns/op    320000 B/op    10000 allocs/op
+BenchmarkCznicSortedGetPut-16          100    14052786 ns/op    963912 B/op    30001 allocs/op
+BenchmarkCznicSortedPut-16             200     7624983 ns/op    641956 B/op    20000 allocs/op
+BenchmarkCznicReversePut-16            200     7599889 ns/op    641956 B/op    20000 allocs/op
+BenchmarkCznicRandomPut-16             200     9212829 ns/op    642221 B/op    20000 allocs/op
+# Note: Could not get iteration to work with B+Tree
 
 # Standard library map (Used as a maximum speed measurement, not sorted like the others)
-BenchmarkMapGet-16                 3000     450179 ns/op         0 B/op        0 allocs/op
-BenchmarkMapSortedGetPut-16        2000     717369 ns/op       791 B/op        0 allocs/op
-BenchmarkMapSortedPut-16           3000     518363 ns/op       522 B/op        0 allocs/op
-BenchmarkMapReversePut-16          2000     550347 ns/op       786 B/op        0 allocs/op
-BenchmarkMapRandomPut-16           2000     514930 ns/op       789 B/op        0 allocs/op
-BenchmarkMapForEach-16            10000     151997 ns/op         0 B/op        0 allocs/op
+BenchmarkMapGet-16                    3000      471404 ns/op         0 B/op        0 allocs/op
+BenchmarkMapSortedGetPut-16           2000      772270 ns/op       787 B/op        0 allocs/op
+BenchmarkMapSortedPut-16              2000      518880 ns/op       785 B/op        0 allocs/op
+BenchmarkMapReversePut-16             2000      558830 ns/op       790 B/op        0 allocs/op
+BenchmarkMapRandomPut-16              2000      538387 ns/op       786 B/op        0 allocs/op
+BenchmarkMapForEach-16               10000      153389 ns/op         0 B/op        0 allocs/op
+
 ```
 
 ## Memory usage

--- a/bytes.go
+++ b/bytes.go
@@ -1,7 +1,7 @@
 package rbTree
 
-// NewBytes will return a new byteslice backend
-func NewBytes() *Bytes {
+// newBytes will return a new byteslice backend
+func newBytes() *Bytes {
 	var b Bytes
 	return &b
 }

--- a/bytes.go
+++ b/bytes.go
@@ -1,9 +1,5 @@
 package rbTree
 
-import (
-	"github.com/missionMeteora/journaler"
-)
-
 // NewBytes will return a new byteslice backend
 func NewBytes() *Bytes {
 	var b Bytes
@@ -15,12 +11,16 @@ type Bytes []byte
 
 func (b *Bytes) grow(sz int64) (bs []byte) {
 	cap := int64(cap(*b))
+	if cap == 0 {
+		cap = sz
+	}
+
 	for cap < sz {
 		cap *= 2
 	}
 
-	*b = make([]byte, cap)
-	bs = *b
-	journaler.Error("Grow")
+	bs = make([]byte, cap)
+	copy(bs, *b)
+	*b = bs
 	return
 }

--- a/bytes.go
+++ b/bytes.go
@@ -1,0 +1,26 @@
+package rbTree
+
+import (
+	"github.com/missionMeteora/journaler"
+)
+
+// NewBytes will return a new byteslice backend
+func NewBytes() *Bytes {
+	var b Bytes
+	return &b
+}
+
+// Bytes manages a byteslice backend
+type Bytes []byte
+
+func (b *Bytes) grow(sz int64) (bs []byte) {
+	cap := int64(cap(*b))
+	for cap < sz {
+		cap *= 2
+	}
+
+	*b = make([]byte, cap)
+	bs = *b
+	journaler.Error("Grow")
+	return
+}

--- a/helpers.go
+++ b/helpers.go
@@ -4,6 +4,13 @@ type color uint8
 
 type childType uint8
 
+type trunk struct {
+	root int64
+	cnt  int64
+	tail int64
+	cap  int64
+}
+
 // ForEachFn is used when calling ForEach from a Tree
 type ForEachFn func(key, val []byte) (end bool)
 

--- a/helpers.go
+++ b/helpers.go
@@ -10,6 +10,9 @@ type ForEachFn func(key, val []byte) (end bool)
 // GrowFn is used when calling grow internally
 type GrowFn func(sz int64) (bs []byte)
 
+// CloseFn is used when close is called
+type CloseFn func() error
+
 func getSize(cnt, keySize, valSize int64) (sz int64) {
 	sz = keySize + valSize + blockSize
 	sz *= cnt

--- a/mmap.go
+++ b/mmap.go
@@ -1,0 +1,84 @@
+package rbTree
+
+import (
+	"os"
+	"path"
+
+	"github.com/edsrzf/mmap-go"
+	"github.com/missionMeteora/journaler"
+	"github.com/missionMeteora/toolkit/errors"
+)
+
+// newMMap will return a new Mmap
+func newMMap(dir, name string) (mp *MMap, err error) {
+	var m MMap
+	if m.f, err = os.OpenFile(path.Join(dir, name), os.O_CREATE|os.O_RDWR, 0644); err != nil {
+		return
+	}
+
+	mp = &m
+	return
+}
+
+// MMap manages the memory mapped file
+type MMap struct {
+	f   *os.File
+	mm  mmap.MMap
+	cap int64
+}
+
+func (m *MMap) unmap() (err error) {
+	if m.mm == nil {
+		return
+	}
+
+	return m.mm.Unmap()
+}
+
+func (m *MMap) grow(sz int64) (bs []byte) {
+	var err error
+	if m.cap == 0 {
+		var fi os.FileInfo
+		if fi, err = m.f.Stat(); err != nil {
+			journaler.Error("Stat error: %v", err)
+			return
+		}
+
+		m.cap = fi.Size()
+	}
+
+	for m.cap < sz {
+		m.cap *= 2
+	}
+
+	if err = m.unmap(); err != nil {
+		journaler.Error("Unmap error: %v", err)
+		return
+	}
+
+	if err = m.f.Truncate(m.cap); err != nil {
+		journaler.Error("Truncate error: %v", err)
+		return
+	}
+
+	if m.mm, err = mmap.Map(m.f, os.O_RDWR, 0); err != nil {
+		journaler.Error("Map error: %v", err)
+		return
+	}
+
+	return m.mm
+}
+
+// Close will close an MMap
+func (m *MMap) Close() (err error) {
+	if m.f == nil {
+		return errors.ErrIsClosed
+	}
+
+	var errs errors.ErrorList
+	errs.Push(m.mm.Flush())
+	errs.Push(m.mm.Unmap())
+	errs.Push(m.f.Close())
+	m.f = nil
+	return
+}

--- a/mmap.go
+++ b/mmap.go
@@ -44,7 +44,9 @@ func (m *MMap) grow(sz int64) (bs []byte) {
 			return
 		}
 
-		m.cap = fi.Size()
+		if m.cap = fi.Size(); m.cap == 0 {
+			m.cap = sz
+		}
 	}
 
 	for m.cap < sz {

--- a/rbTree.go
+++ b/rbTree.go
@@ -28,7 +28,7 @@ var (
 // New will return a new Tree
 // sz is the size (in bytes) to initially allocate for this db
 func New(sz int64) (t *Tree) {
-	bs := NewBytes()
+	bs := newBytes()
 	t = newTree(sz, bs.grow, nil)
 	return
 }

--- a/rbTree_test.go
+++ b/rbTree_test.go
@@ -25,7 +25,7 @@ var (
 )
 
 func TestBasic(t *testing.T) {
-	tr, err := NewMMAP("data", "mmap.db", 2, 2, 2)
+	tr, err := NewMMAP("data", "mmap.db", 64)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestBasic(t *testing.T) {
 
 	tr.Close()
 
-	if tr, err = NewMMAP("data", "mmap.db", 2, 2, 2); err != nil {
+	if tr, err = NewMMAP("data", "mmap.db", 64); err != nil {
 		t.Fatal(err)
 	}
 
@@ -262,7 +262,7 @@ func BenchmarkSkiplistForEach(b *testing.B) {
 
 func testPut(t *testing.T, s []int) {
 	cnt := len(s)
-	tr := New(int64(cnt), 8, 8)
+	tr := New(1024 * 1024)
 	tm := make(map[string][]byte, cnt)
 
 	for _, v := range s {
@@ -295,7 +295,7 @@ func testPut(t *testing.T, s []int) {
 }
 
 func benchGet(b *testing.B, s []kv) {
-	tr := New(int64(len(s)), 8, 8)
+	tr := New(1024)
 	for _, kv := range s {
 		tr.Put(kv.val, kv.val)
 	}
@@ -309,7 +309,7 @@ func benchGet(b *testing.B, s []kv) {
 }
 
 func benchPut(b *testing.B, s []kv) {
-	tr := New(int64(len(s)), 8, 8)
+	tr := New(1024 * 1024)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -320,7 +320,7 @@ func benchPut(b *testing.B, s []kv) {
 }
 
 func benchGetPut(b *testing.B, s []kv) {
-	tr := New(int64(len(s)), 8, 8)
+	tr := New(1024 * 1024)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -332,7 +332,7 @@ func benchGetPut(b *testing.B, s []kv) {
 }
 
 func benchForEach(b *testing.B, s []kv) {
-	tr := New(int64(len(s)), 8, 8)
+	tr := New(1024 * 1024)
 
 	for _, kv := range s {
 		tr.Put(kv.val, kv.val)
@@ -348,7 +348,7 @@ func benchForEach(b *testing.B, s []kv) {
 }
 
 func benchMMAPGet(b *testing.B, s []kv) {
-	tr, err := NewMMAP("data", "test.db", int64(len(s)), 8, 8)
+	tr, err := NewMMAP("data", "test.db", 1024*1024)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -367,7 +367,7 @@ func benchMMAPGet(b *testing.B, s []kv) {
 }
 
 func benchMMAPPut(b *testing.B, s []kv) {
-	tr, err := NewMMAP("data", "test.db", int64(len(s)), 8, 8)
+	tr, err := NewMMAP("data", "test.db", 1024*1024)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -382,7 +382,7 @@ func benchMMAPPut(b *testing.B, s []kv) {
 }
 
 func benchMMAPGetPut(b *testing.B, s []kv) {
-	tr, err := NewMMAP("data", "test.db", int64(len(s)), 8, 8)
+	tr, err := NewMMAP("data", "test.db", 1024*1024)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -398,7 +398,7 @@ func benchMMAPGetPut(b *testing.B, s []kv) {
 }
 
 func benchMMAPForEach(b *testing.B, s []kv) {
-	tr, err := NewMMAP("data", "test.db", int64(len(s)), 8, 8)
+	tr, err := NewMMAP("data", "test.db", 1024*1024)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/rbTree_test.go
+++ b/rbTree_test.go
@@ -609,24 +609,30 @@ func benchCznicForEach(b *testing.B, s []kv) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		e, ok := tr.Seek([]byte("1"))
+		e, ok := tr.Seek([]byte(""))
 		if !ok {
 			b.Fatal("error calling iterator")
 		}
 
-		cnt := 0
-		for _, v, err := e.Next(); err != nil; _, v, err = e.Next() {
+		var (
+			v   interface{}
+			err error
+			cnt int
+		)
+
+		for _, v, err = e.Next(); err == nil; _, v, err = e.Next() {
 			testCznicVal = v
+			cnt++
 		}
 
 		if cnt != len(s) {
-			b.Fatalf("invalid count, expected %v and received %v", len(s), cnt)
+			b.Fatalf("invalid count, expected %v and received %v (%v)", len(s), cnt, err)
 		}
 	}
 }
 
 func getStrSlice(in []int) (out []kv) {
-	out = make([]kv, len(in))
+	out = make([]kv, 0, len(in))
 
 	for _, v := range in {
 		var kv kv


### PR DESCRIPTION
For the most part, the performance is identical. This commit greatly cleans up the backend system. If there are any suggestions, I am all ears!

```bash
name                    old time/op    new time/op    delta
RBTGet-16                 3.39ms ± 1%    3.41ms ± 3%    ~     (p=0.548 n=5+5)
RBTSortedGetPut-16        6.94ms ± 2%    7.01ms ± 2%    ~     (p=0.421 n=5+5)
RBTSortedPut-16           3.73ms ± 2%    3.70ms ± 2%    ~     (p=0.690 n=5+5)
RBTReversePut-16          3.69ms ± 2%    3.74ms ± 2%    ~     (p=0.421 n=5+5)
RBTRandomPut-16           4.09ms ± 2%    4.13ms ± 0%  +0.81%  (p=0.032 n=5+4)
RBTForEach-16             93.9µs ± 1%    93.9µs ± 1%    ~     (p=1.000 n=5+5)
RBTMMapGet-16             3.42ms ± 2%    3.43ms ± 2%    ~     (p=0.421 n=5+5)
RBTMMapSortedGetPut-16    6.93ms ± 2%    7.03ms ± 3%    ~     (p=0.222 n=5+5)
RBTMMapSortedPut-16       3.69ms ± 3%    3.76ms ± 2%    ~     (p=0.222 n=5+5)
RBTMMapReversePut-16      3.68ms ± 2%    3.76ms ± 2%    ~     (p=0.056 n=5+5)
RBTMMapRandomPut-16       4.35ms ± 3%    4.39ms ± 2%    ~     (p=0.421 n=5+5)
RBTMMapForEach-16         93.1µs ± 2%    93.8µs ± 1%    ~     (p=0.421 n=5+5)

name                    old alloc/op   new alloc/op   delta
RBTGet-16                  0.00B          0.00B         ~     (all equal)
RBTSortedGetPut-16         0.00B          0.00B         ~     (all equal)
RBTSortedPut-16            0.00B          0.00B         ~     (all equal)
RBTReversePut-16           0.00B          0.00B         ~     (all equal)
RBTRandomPut-16            0.00B          0.00B         ~     (all equal)
RBTForEach-16              0.00B          0.00B         ~     (all equal)
RBTMMapGet-16              0.00B          0.00B         ~     (all equal)
RBTMMapSortedGetPut-16     0.00B          0.00B         ~     (all equal)
RBTMMapSortedPut-16        0.00B          0.00B         ~     (all equal)
RBTMMapReversePut-16       0.00B          0.00B         ~     (all equal)
RBTMMapRandomPut-16        0.00B          0.00B         ~     (all equal)
RBTMMapForEach-16          0.00B          0.00B         ~     (all equal)

name                    old allocs/op  new allocs/op  delta
RBTGet-16                   0.00           0.00         ~     (all equal)
RBTSortedGetPut-16          0.00           0.00         ~     (all equal)
RBTSortedPut-16             0.00           0.00         ~     (all equal)
RBTReversePut-16            0.00           0.00         ~     (all equal)
RBTRandomPut-16             0.00           0.00         ~     (all equal)
RBTForEach-16               0.00           0.00         ~     (all equal)
RBTMMapGet-16               0.00           0.00         ~     (all equal)
RBTMMapSortedGetPut-16      0.00           0.00         ~     (all equal)
RBTMMapSortedPut-16         0.00           0.00         ~     (all equal)
RBTMMapReversePut-16        0.00           0.00         ~     (all equal)
RBTMMapRandomPut-16         0.00           0.00         ~     (all equal)
RBTMMapForEach-16           0.00           0.00         ~     (all equal)
```
